### PR TITLE
Support for installing multiple etcd releases in the same Namespace

### DIFF
--- a/charts/kamaji-etcd/Chart.yaml
+++ b/charts/kamaji-etcd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kamaji-etcd/Makefile
+++ b/charts/kamaji-etcd/Makefile
@@ -1,0 +1,9 @@
+docs: HELMDOCS_VERSION := v1.8.1
+docs: docker
+	@docker run --rm -v "$$(pwd):/helm-docs" -u $$(id -u) jnorwood/helm-docs:$(HELMDOCS_VERSION)
+
+docker:
+	@hash docker 2>/dev/null || {\
+		echo "You need docker" &&\
+		exit 1;\
+	}

--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -1,6 +1,6 @@
 # kamaji-etcd
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.4](https://img.shields.io/badge/AppVersion-3.5.4-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.4](https://img.shields.io/badge/AppVersion-3.5.4-informational?style=flat-square)
 
 Helm chart for deploying a multi-tenant `etcd` cluster.
 
@@ -63,9 +63,7 @@ Here the values you can override:
 | alerts.rules | list | `[]` | The rules for alerts |
 | autoCompactionMode | string | `"periodic"` | Interpret 'auto-compaction-retention' one of: periodic|revision. Use 'periodic' for duration based retention, 'revision' for revision number based retention. |
 | autoCompactionRetention | string | `"5m"` | Auto compaction retention length. 0 means disable auto compaction. |
-| caSecret | string | `"etcd-certs"` | Name of the secret which contains CA's certificate and private key. (default: "etcd-certs") |
 | clientPort | int | `2379` | The client request port. |
-| clientSecret | string | `"root-client-certs"` | Name of the secret which contains ETCD client certificates. (default: "root-client-certs") |
 | defragmentation | object | `{"schedule":"*/15 * * * *"}` | Enable storage defragmentation  |
 | defragmentation.schedule | string | `"*/15 * * * *"` | The job scheduled maintenance time for defrag (empty to disable) |
 | extraArgs | list | `[]` | A list of extra arguments to add to the etcd default ones |
@@ -80,7 +78,7 @@ Here the values you can override:
 | persistenVolumeClaim.size | string | `"10Gi"` | The size of persistent storage for etcd data  |
 | persistenVolumeClaim.storageClass | string | `""` | A specific storage class |
 | podAnnotations | object | `{}` | Annotations to add to all etcd pods |
-| podLabels | object | `{"application":"kamaji-etcd","foo":"bar"}` | Labels to add to all etcd pods |
+| podLabels | object | `{"application":"kamaji-etcd"}` | Labels to add to all etcd pods |
 | priorityClassName | string | `"system-cluster-critical"` | The priorityClassName to apply to etcd |
 | quotaBackendBytes | string | `"8589934592"` | Raise alarms when backend size exceeds the given quota. It will put the cluster into a maintenance mode which only accepts key reads and deletes.  |
 | replicas | int | `3` | Size of the etcd cluster |

--- a/charts/kamaji-etcd/templates/_helpers.tpl
+++ b/charts/kamaji-etcd/templates/_helpers.tpl
@@ -79,6 +79,20 @@ Name of the certificate signing requests for the certificates required by etcd.
 {{- end }}
 
 {{/*
+Name of the etcd role
+*/}}
+{{- define "etcd.roleName" }}
+{{- printf "%s-gen-certs-role" (include "etcd.fullname" .) }}
+{{- end }}
+
+{{/*
+Name of the etcd role binding
+*/}}
+{{- define "etcd.roleBindingName" }}
+{{- printf "%s-gen-certs-rolebiding" (include "etcd.fullname" .) }}
+{{- end }}
+
+{{/*
 Name of the etcd root-client secret.
 */}}
 {{- define "etcd.clientSecretName" }}

--- a/charts/kamaji-etcd/templates/etcd_cm.yaml
+++ b/charts/kamaji-etcd/templates/etcd_cm.yaml
@@ -1,3 +1,4 @@
+{{- $outer := $ -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -52,7 +53,7 @@ data:
       },
       "hosts": [
 {{- range $count := until (int $.Values.replicas) -}}
-        {{ printf "\"etcd-%d.%s.%s.svc.cluster.local\"," $count (include "etcd.serviceName" .) $.Release.Namespace }}
+        {{ printf "\"%s-%d.%s.%s.svc.cluster.local\"," ( include "etcd.fullname" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace }}
 {{- end }}
         "etcd-server.{{ .Release.Namespace }}.svc.cluster.local",
         "etcd-server.{{ .Release.Namespace }}.svc",
@@ -69,10 +70,10 @@ data:
       },
       "hosts": [
 {{- range $count := until (int $.Values.replicas) -}}
-        {{ printf "\"etcd-%d\"," $count }}
-        {{ printf "\"etcd-%d.%s\"," $count (include "etcd.serviceName" .) }}
-        {{ printf "\"etcd-%d.%s.%s.svc\"," $count (include "etcd.serviceName" .) $.Release.Namespace }}
-        {{ printf "\"etcd-%d.%s.%s.svc.cluster.local\"," $count (include "etcd.serviceName" .) $.Release.Namespace }}
+        {{ printf "\"%s-%d\"," ( include "etcd.stsName" $outer ) $count }}
+        {{ printf "\"%s-%d.%s\"," ( include "etcd.stsName" $outer ) $count (include "etcd.serviceName" $outer) }}
+        {{ printf "\"%s-%d.%s.%s.svc\"," ( include "etcd.stsName" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace }}
+        {{ printf "\"%s-%d.%s.%s.svc.cluster.local\"," ( include "etcd.stsName" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace }}
 {{- end }}
         "127.0.0.1"
       ]

--- a/charts/kamaji-etcd/templates/etcd_job_postinstall_1.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_postinstall_1.yaml
@@ -5,9 +5,9 @@ metadata:
     {{- include "etcd.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
-  name: "{{ .Release.Name }}-etcd-setup"
+  name: "{{ .Release.Name }}-etcd-setup-1"
   namespace: {{ .Release.Namespace }}
 spec:
   template:
@@ -33,6 +33,7 @@ spec:
               name: certs
             - mountPath: /csr
               name: csr
+      containers:
         - name: kubectl
           image: {{ printf "clastix/kubectl:%s" (include "etcd.jobsTagKubeVersion" .) }}
           command:
@@ -42,46 +43,15 @@ spec:
               kubectl --namespace={{ .Release.Namespace }} delete secret --ignore-not-found=true {{ include "etcd.caSecretName" . }} {{ include "etcd.clientSecretName" . }} &&
               kubectl --namespace={{ .Release.Namespace }} create secret generic {{ include "etcd.caSecretName" . }} --from-file=/certs/ca.crt --from-file=/certs/ca.key --from-file=/certs/peer-key.pem --from-file=/certs/peer.pem --from-file=/certs/server-key.pem --from-file=/certs/server.pem &&
               kubectl --namespace={{ .Release.Namespace }} create secret tls {{ include "etcd.clientSecretName" . }} --key=/certs/root-client-key.pem --cert=/certs/root-client.pem &&
-              kubectl --namespace={{ .Release.Namespace }} rollout status sts/etcd --timeout=300s
+              kubectl --namespace={{ .Release.Namespace }} rollout status sts/{{ include "etcd.stsName" . }} --timeout=300s
           volumeMounts:
             - mountPath: /certs
               name: certs
-      containers:
-        - command:
-          - bash
-          - -c
-          - |-
-            etcdctl member list -w table &&
-            etcdctl user add --no-password=true root &&
-            etcdctl role add root &&
-            etcdctl user grant-role root root &&
-            etcdctl auth enable
-          env:
-            - name: ETCDCTL_ENDPOINTS
-              value: https://etcd-0.{{ include "etcd.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.clientPort }}
-            - name: ETCDCTL_CACERT
-              value: /opt/certs/ca/ca.crt
-            - name: ETCDCTL_CERT
-              value: /opt/certs/root-certs/tls.crt
-            - name: ETCDCTL_KEY
-              value: /opt/certs/root-certs/tls.key
-          image: {{ include "etcd.fullyQualifiedDockerImage" . }}
-          imagePullPolicy: IfNotPresent
-          name: etcd-client
-          volumeMounts:
-            - name: root-certs
-              mountPath: /opt/certs/root-certs
-            - name: certs
-              mountPath: /opt/certs/ca
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
       volumes:
-        - name: root-certs
-          secret:
-            secretName: {{ include "etcd.clientSecretName" . }}
-            optional: true
         - name: csr
           configMap:
             name: {{ include "etcd.csrConfigMapName" . }}

--- a/charts/kamaji-etcd/templates/etcd_job_postinstall_2.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_postinstall_2.yaml
@@ -1,0 +1,57 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    {{- include "etcd.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+  name: "{{ .Release.Name }}-etcd-setup-2"
+  namespace: {{ .Release.Namespace }}
+spec:
+  backoffLimit: 12
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+    spec:
+      serviceAccountName: {{ include "etcd.serviceAccountName" . }}
+      restartPolicy: Never
+      containers:
+        - command:
+          - bash
+          - -c
+          - |-
+            etcdctl member list -w table &&
+            etcdctl user add --no-password=true root &&
+            etcdctl role add root &&
+            etcdctl user grant-role root root &&
+            etcdctl auth enable
+          env:
+            - name: ETCDCTL_ENDPOINTS
+              value: https://{{ include "etcd.fullname" . }}-0.{{ include "etcd.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.clientPort }}
+            - name: ETCDCTL_CACERT
+              value: /opt/certs/ca/ca.crt
+            - name: ETCDCTL_CERT
+              value: /opt/certs/root-certs/tls.crt
+            - name: ETCDCTL_KEY
+              value: /opt/certs/root-certs/tls.key
+          image: {{ include "etcd.fullyQualifiedDockerImage" . }}
+          imagePullPolicy: IfNotPresent
+          name: etcd-client
+          volumeMounts:
+            - name: root-certs
+              mountPath: /opt/certs/root-certs
+            - name: ca
+              mountPath: /opt/certs/ca
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      volumes:
+        - name: root-certs
+          secret:
+            secretName: {{ include "etcd.clientSecretName" . }}
+        - name: ca
+          secret:
+            secretName: {{ include "etcd.caSecretName" . }}

--- a/charts/kamaji-etcd/templates/etcd_rbac.yaml
+++ b/charts/kamaji-etcd/templates/etcd_rbac.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
-  name: etcd-gen-certs-role
+  name: {{ include "etcd.roleName" . }}
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:
@@ -29,18 +29,20 @@ rules:
       - get
       - list
       - watch
+    resourceNames:
+      - {{ include "etcd.fullname" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
-  name: etcd-gen-certs-rolebiding
+  name: {{ include "etcd.roleBindingName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: etcd-gen-certs-role
+  name: {{ include "etcd.roleName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "etcd.serviceAccountName" . }}

--- a/charts/kamaji-etcd/templates/etcd_rbac.yaml
+++ b/charts/kamaji-etcd/templates/etcd_rbac.yaml
@@ -30,7 +30,7 @@ rules:
       - list
       - watch
     resourceNames:
-      - {{ include "etcd.fullname" . }}
+      - {{ include "etcd.stsName" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/kamaji-etcd/templates/etcd_sts.yaml
+++ b/charts/kamaji-etcd/templates/etcd_sts.yaml
@@ -3,7 +3,7 @@ kind: StatefulSet
 metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
-  name: {{ include "etcd.fullname" . }}
+  name: {{ include "etcd.stsName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   serviceName: {{ include "etcd.serviceName" . }}
@@ -53,8 +53,8 @@ spec:
             - --name=$(POD_NAME)
             - --initial-cluster-state=new
             - --initial-cluster={{ include "etcd.initialCluster" . }}
-            - --initial-advertise-peer-urls=https://$(POD_NAME).etcd.$(POD_NAMESPACE).svc.cluster.local:{{ .Values.peerApiPort }}
-            - --advertise-client-urls=https://$(POD_NAME).etcd.$(POD_NAMESPACE).svc.cluster.local:{{ .Values.clientPort }}
+            - --initial-advertise-peer-urls=https://$(POD_NAME).{{ include "etcd.serviceName" . }}.$(POD_NAMESPACE).svc.cluster.local:{{ .Values.peerApiPort }}
+            - --advertise-client-urls=https://$(POD_NAME).{{ include "etcd.serviceName" . }}.$(POD_NAMESPACE).svc.cluster.local:{{ .Values.clientPort }}
             - --initial-cluster-token=kamaji
             - --listen-client-urls=https://0.0.0.0:{{ .Values.clientPort }}
             - --listen-metrics-urls=http://0.0.0.0:{{ .Values.metricsPort }}

--- a/charts/kamaji-etcd/values.yaml
+++ b/charts/kamaji-etcd/values.yaml
@@ -12,12 +12,6 @@ serviceAccount:
   # -- Define the ServiceAccount name to use during the setup and provision of the etcd backing storage (default: "")
   name: ""
 
-# -- Name of the secret which contains CA's certificate and private key. (default: "etcd-certs")
-caSecret: etcd-certs
-
-# -- Name of the secret which contains ETCD client certificates. (default: "root-client-certs")
-clientSecret: root-client-certs
-
 image:
   # -- Install image from specific repo 
   repository: quay.io/coreos/etcd

--- a/charts/kamaji-etcd/values.yaml
+++ b/charts/kamaji-etcd/values.yaml
@@ -80,7 +80,6 @@ defragmentation:
 # -- Labels to add to all etcd pods
 podLabels:
   application: kamaji-etcd
-  foo: bar
 
 # -- Annotations to add to all etcd pods
 podAnnotations: {}


### PR DESCRIPTION
This PR allows to install multiple instances of the `kamaji-etcd` chart in the same namespace:

```
$: helm list
NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
bronze  etcd-system     1               2022-11-29 12:13:18.743916832 +0100 CET deployed        kamaji-etcd-0.2.0       3.5.4      
gold    etcd-system     1               2022-11-29 12:10:41.67770202 +0100 CET  deployed        kamaji-etcd-0.2.0       3.5.4      
shared  etcd-system     1               2022-11-29 14:22:37.55830414 +0100 CET  deployed        kamaji-etcd-0.2.0       3.5.4      
silver  etcd-system     1               2022-11-29 12:12:09.156124811 +0100 CET deployed        kamaji-etcd-0.2.0       3.5.4
```

Along with that, some bug fix and clean-up activities.