### PR TITLE
fix: datastore resource object hook

### DIFF
--- a/charts/kamaji-etcd/Chart.yaml
+++ b/charts/kamaji-etcd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -1,6 +1,6 @@
 # kamaji-etcd
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.6](https://img.shields.io/badge/AppVersion-3.5.6-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.6](https://img.shields.io/badge/AppVersion-3.5.6-informational?style=flat-square)
 
 Helm chart for deploying a multi-tenant `etcd` cluster.
 

--- a/charts/kamaji-etcd/templates/etcd_cm.yaml
+++ b/charts/kamaji-etcd/templates/etcd_cm.yaml
@@ -2,6 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "5"
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   name: {{ include "etcd.csrConfigMapName" . }}

--- a/charts/kamaji-etcd/templates/etcd_datastore.yaml
+++ b/charts/kamaji-etcd/templates/etcd_datastore.yaml
@@ -3,9 +3,6 @@ apiVersion: kamaji.clastix.io/v1alpha1
 kind: DataStore
 metadata:
   name: {{ include "etcd.fullname" . }}
-  annotations:
-    "helm.sh/hook": post-install,post-delete
-    "helm.sh/hook-weight": "5"
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
 spec:

--- a/charts/kamaji-etcd/templates/etcd_datastore.yaml
+++ b/charts/kamaji-etcd/templates/etcd_datastore.yaml
@@ -4,7 +4,7 @@ kind: DataStore
 metadata:
   name: {{ include "etcd.fullname" . }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade,post-rollback
+    "helm.sh/hook": post-install,post-delete
     "helm.sh/hook-weight": "5"
   labels:
     {{- include "etcd.labels" . | nindent 4 }}

--- a/charts/kamaji-etcd/templates/etcd_job_postdelete.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_postdelete.yaml
@@ -5,7 +5,7 @@ metadata:
     {{- include "etcd.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   name: "{{ .Release.Name }}-etcd-teardown"
   namespace: {{ .Release.Namespace }}

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
@@ -4,8 +4,8 @@ metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "1"
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   name: "{{ .Release.Name }}-etcd-setup-1"
   namespace: {{ .Release.Namespace }}
@@ -42,8 +42,7 @@ spec:
             - |-
               kubectl --namespace={{ .Release.Namespace }} delete secret --ignore-not-found=true {{ include "etcd.caSecretName" . }} {{ include "etcd.clientSecretName" . }} &&
               kubectl --namespace={{ .Release.Namespace }} create secret generic {{ include "etcd.caSecretName" . }} --from-file=/certs/ca.crt --from-file=/certs/ca.key --from-file=/certs/peer-key.pem --from-file=/certs/peer.pem --from-file=/certs/server-key.pem --from-file=/certs/server.pem &&
-              kubectl --namespace={{ .Release.Namespace }} create secret tls {{ include "etcd.clientSecretName" . }} --key=/certs/root-client-key.pem --cert=/certs/root-client.pem &&
-              kubectl --namespace={{ .Release.Namespace }} rollout status sts/{{ include "etcd.stsName" . }} --timeout=300s
+              kubectl --namespace={{ .Release.Namespace }} create secret tls {{ include "etcd.clientSecretName" . }} --key=/certs/root-client-key.pem --cert=/certs/root-client.pem
           volumeMounts:
             - mountPath: /certs
               name: certs

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
@@ -17,6 +17,13 @@ spec:
     spec:
       serviceAccountName: {{ include "etcd.serviceAccountName" . }}
       restartPolicy: Never
+      initContainers:
+        - name: kubectl
+          image: {{ printf "clastix/kubectl:%s" (include "etcd.jobsTagKubeVersion" .) }}
+          command:
+          - sh
+          - -c
+          - kubectl --namespace={{ .Release.Namespace }} rollout status sts/{{ include "etcd.stsName" . }} --timeout=300s
       containers:
         - command:
           - bash

--- a/charts/kamaji-etcd/templates/etcd_rbac.yaml
+++ b/charts/kamaji-etcd/templates/etcd_rbac.yaml
@@ -1,6 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  annotations:
+    "helm.sh/hook": pre-install,post-install,pre-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "5"
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   name: {{ include "etcd.roleName" . }}
@@ -38,6 +42,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  annotations:
+    "helm.sh/hook": pre-install,post-install,pre-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "5"
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   name: {{ include "etcd.roleBindingName" . }}

--- a/charts/kamaji-etcd/templates/etcd_sa.yaml
+++ b/charts/kamaji-etcd/templates/etcd_sa.yaml
@@ -5,8 +5,11 @@ metadata:
   name: {{ include "etcd.serviceAccountName" . }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
   annotations:
+    "helm.sh/hook": pre-install,post-install,pre-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-weight": "0"
+  {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/kamaji-etcd/templates/etcd_sts.yaml
+++ b/charts/kamaji-etcd/templates/etcd_sts.yaml
@@ -24,7 +24,6 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}      
     spec:
-      serviceAccountName: {{ include "etcd.serviceAccountName" . }}
       volumes:
         - name: certs
           secret:


### PR DESCRIPTION
Fixes #38.

The hook list was wrong, causing a deletion of the DataStore upon an update, or a rollback.