### PR TITLE
Keeping ServiceAccount after successful pre-install phase

### DIFF
--- a/charts/kamaji-etcd/Chart.yaml
+++ b/charts/kamaji-etcd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -1,6 +1,6 @@
 # kamaji-etcd
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.6](https://img.shields.io/badge/AppVersion-3.5.6-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.6](https://img.shields.io/badge/AppVersion-3.5.6-informational?style=flat-square)
 
 Helm chart for deploying a multi-tenant `etcd` cluster.
 

--- a/charts/kamaji-etcd/templates/etcd_sa.yaml
+++ b/charts/kamaji-etcd/templates/etcd_sa.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install,post-install,pre-delete
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": "hook-failed"
     "helm.sh/hook-weight": "0"
   {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Closes #46.

@Heiko-san please, may I ask you to give it a try?

I was able to create a Helm release, with the ServiceAccount kept even after the successful installation.
The downside is that we're wrongly managing the Helm hooks, and we need to introduce some breaking changes with some new Helm values, I want to make the transition as smooth as possible.

When you delete the Helm release, you will notice the ServiceAccount is still there, non-deleted by Helm itself: this will be fixed for one of the upcoming minor changes.