### PR TITLE
fix(helm): persistentVolume key typo

### DIFF
--- a/charts/kamaji-etcd/Chart.yaml
+++ b/charts/kamaji-etcd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -1,6 +1,6 @@
 # kamaji-etcd
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.6](https://img.shields.io/badge/AppVersion-3.5.6-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.6](https://img.shields.io/badge/AppVersion-3.5.6-informational?style=flat-square)
 
 Helm chart for deploying a multi-tenant `etcd` cluster.
 
@@ -91,10 +91,10 @@ Here the values you can override:
 | metricsPort | int | `2381` | The port where etcd exposes metrics. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Kubernetes node selector rules to schedule etcd |
 | peerApiPort | int | `2380` | The peer API port which servers are listening to. |
-| persistenVolumeClaim.accessModes | list | `["ReadWriteOnce"]` | The Access Mode to storage |
-| persistenVolumeClaim.customAnnotations | object | `{}` | The custom annotations to add to the PVC |
-| persistenVolumeClaim.size | string | `"10Gi"` | The size of persistent storage for etcd data  |
-| persistenVolumeClaim.storageClassName | string | `""` | A specific storage class |
+| persistentVolumeClaim.accessModes | list | `["ReadWriteOnce"]` | The Access Mode to storage |
+| persistentVolumeClaim.customAnnotations | object | `{}` | The custom annotations to add to the PVC |
+| persistentVolumeClaim.size | string | `"10Gi"` | The size of persistent storage for etcd data  |
+| persistentVolumeClaim.storageClassName | string | `""` | A specific storage class |
 | podAnnotations | object | `{}` | Annotations to add to all etcd pods |
 | podLabels | object | `{"application":"kamaji-etcd"}` | Labels to add to all etcd pods |
 | priorityClassName | string | `"system-cluster-critical"` | The priorityClassName to apply to etcd |

--- a/charts/kamaji-etcd/templates/etcd_sts.yaml
+++ b/charts/kamaji-etcd/templates/etcd_sts.yaml
@@ -102,16 +102,16 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
-        {{- with .Values.persistenVolumeClaim.customAnnotations }}
+        {{- with .Values.persistentVolumeClaim.customAnnotations }}
         annotations:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
-        storageClassName: {{ .Values.persistenVolumeClaim.storageClassName }}
+        storageClassName: {{ .Values.persistentVolumeClaim.storageClassName }}
         accessModes:
-        {{- range .Values.persistenVolumeClaim.accessModes }}
+        {{- range .Values.persistentVolumeClaim.accessModes }}
         - {{ . | quote }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.persistenVolumeClaim.size }}
+            storage: {{ .Values.persistentVolumeClaim.size }}

--- a/charts/kamaji-etcd/values.yaml
+++ b/charts/kamaji-etcd/values.yaml
@@ -57,7 +57,7 @@ snapshotCount: "10000"
 # -- Raise alarms when backend size exceeds the given quota. It will put the cluster into a maintenance mode which only accepts key reads and deletes. 
 quotaBackendBytes: "8589934592" # 8Gi
 
-persistenVolumeClaim:
+persistentVolumeClaim:
   # -- The size of persistent storage for etcd data 
   size: 10Gi
   # -- A specific storage class


### PR DESCRIPTION
Caught another typo that bit me. I'm increasing the helm minor version by 1 due to the nature of the change.
Do we deal with "old" configs that are going to miss the change?