### PR TITLE
Specify hook-delete-strategy: before-hook-creation

### DIFF
--- a/charts/kamaji-etcd/templates/etcd_job_postdelete.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_postdelete.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation,hook-failed"
   name: "{{ .Release.Name }}-etcd-teardown"
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation,hook-failed"
   name: "{{ .Release.Name }}-etcd-setup-1"
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation,hook-failed"
   name: "{{ .Release.Name }}-etcd-setup-2"
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/kamaji-etcd/templates/etcd_job_s3retention.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_s3retention.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation,hook-failed"
   name: "{{ .Release.Name }}-s3-retention"
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/kamaji-etcd/templates/etcd_rbac.yaml
+++ b/charts/kamaji-etcd/templates/etcd_rbac.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   annotations:
     "helm.sh/hook": pre-install,post-install,pre-delete
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation,hook-failed"
     "helm.sh/hook-weight": "5"
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
@@ -44,7 +44,7 @@ kind: RoleBinding
 metadata:
   annotations:
     "helm.sh/hook": pre-install,post-install,pre-delete
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation,hook-failed"
     "helm.sh/hook-weight": "5"
   labels:
     {{- include "etcd.labels" . | nindent 4 }}

--- a/charts/kamaji-etcd/templates/etcd_sa.yaml
+++ b/charts/kamaji-etcd/templates/etcd_sa.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "etcd.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": "hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-failed"
     "helm.sh/hook-weight": "0"
   {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Sometimes, if etcd is not correctly installed or uninstalled, the creation of hooks may block further operations.

Specifying `before-hook-creation` can help avoid these kinds of issues.