### PR TITLE
Add the ability to access etcd without specifying cluster.local suffix for FQDN

### DIFF
--- a/charts/kamaji-etcd/templates/etcd_cm.yaml
+++ b/charts/kamaji-etcd/templates/etcd_cm.yaml
@@ -57,6 +57,7 @@ data:
       "hosts": [
 {{- range $count := until (int $.Values.replicas) -}}
         {{ printf "\"%s-%d.%s.%s.svc.cluster.local\"," ( include "etcd.fullname" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace }}
+        {{ printf "\"%s-%d.%s.%s.svc\"," ( include "etcd.fullname" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace }}
 {{- end }}
         "etcd-server.{{ .Release.Namespace }}.svc.cluster.local",
         "etcd-server.{{ .Release.Namespace }}.svc",


### PR DESCRIPTION
Domain `cluster.local` can be changed by cluster admin, so it's better
to use universal short name.
