### PR TITLE
Always remove plus from minor version

### DIFF
--- a/charts/kamaji-etcd/templates/_helpers.tpl
+++ b/charts/kamaji-etcd/templates/_helpers.tpl
@@ -110,11 +110,7 @@ Name of the etcd root-client secret.
 Retrieve the current Kubernetes version to launch a kubectl container with the minimum version skew possible.
 */}}
 {{- define "etcd.jobsTagKubeVersion" -}}
-{{- if contains "-eks-" .Capabilities.KubeVersion.GitVersion }}
 {{- print "v" .Capabilities.KubeVersion.Major "." (.Capabilities.KubeVersion.Minor | replace "+" "") -}}
-{{- else }}
-{{- print "v" .Capabilities.KubeVersion.Major "." .Capabilities.KubeVersion.Minor -}}
-{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
Hi, it makes sense to remove `+` from minor not only for aws.

We're using Talos Linux and also faced with this problem:

```
Server Version: v1.29.0-rc.1
```

Helm recogizes as `v1.29+` and appends it into image tag