### PR TITLE
Dont assume cluster domain

### DIFF
--- a/charts/kamaji-etcd/Chart.yaml
+++ b/charts/kamaji-etcd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -27,7 +27,7 @@ home: https://github.com/clastix/kamaji-etcd
 sources: ["https://github.com/clastix/kamaji-etcd"]
 kubeVersion: ">=1.22.0-0"
 maintainers:
-- email: me@bsctl.io
-  name: Adriano Pezzuto
-- email: dario@tranchitella.eu
-  name: Dario Tranchitella
+  - email: me@bsctl.io
+    name: Adriano Pezzuto
+  - email: dario@tranchitella.eu
+    name: Dario Tranchitella

--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -1,6 +1,6 @@
 # kamaji-etcd
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.6](https://img.shields.io/badge/AppVersion-3.5.6-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.6](https://img.shields.io/badge/AppVersion-3.5.6-informational?style=flat-square)
 
 Helm chart for deploying a multi-tenant `etcd` cluster.
 
@@ -80,6 +80,7 @@ Here the values you can override:
 | backup.snapshotDateFormat | string | `"$(date +%Y%m%d)"` | The backup file date format (bash) |
 | backup.snapshotNamePrefix | string | `"mysnapshot"` | The backup file name prefix |
 | clientPort | int | `2379` | The client request port. |
+| clusterDomain | string | `"cluster.local"` | Domain of the Kubernetes cluster. |
 | datastore.enabled | bool | `false` | Create a datastore custom resource for Kamaji |
 | defragmentation | object | `{"schedule":"*/15 * * * *"}` | Enable storage defragmentation  |
 | defragmentation.schedule | string | `"*/15 * * * *"` | The job scheduled maintenance time for defrag (empty to disable) |

--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -1,6 +1,6 @@
 # kamaji-etcd
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.6](https://img.shields.io/badge/AppVersion-3.5.6-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.6](https://img.shields.io/badge/AppVersion-3.5.6-informational?style=flat-square)
 
 Helm chart for deploying a multi-tenant `etcd` cluster.
 

--- a/charts/kamaji-etcd/templates/_helpers.tpl
+++ b/charts/kamaji-etcd/templates/_helpers.tpl
@@ -124,7 +124,7 @@ Comma separated list of etcd cluster peers.
 {{- $outer := . -}}
 {{- $list := list -}}
 {{- range $i, $count := until (int $.Values.replicas) -}}
-    {{- $list = append $list ( printf "%s-%d=https://%s-%d.%s.%s.svc.%s:%d" ( include "etcd.stsName" $outer ) $i ( include "etcd.fullname" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace (int $.Values.peerApiPort) $.Values.clusterDomain ) -}}
+    {{- $list = append $list ( printf "%s-%d=https://%s-%d.%s.%s.svc.%s:%d" ( include "etcd.stsName" $outer ) $i ( include "etcd.fullname" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace $.Values.clusterDomain (int $.Values.peerApiPort) ) -}}
 {{- end }}
 {{- join "," $list -}}
 {{- end }}
@@ -136,7 +136,7 @@ Space separated list of etcd cluster endpoints.
 {{- $outer := . -}}
 {{- $list := list -}}
 {{- range $i, $count := until (int $.Values.replicas) -}}
-    {{- $list = append $list ( printf "%s-%d.%s.%s.svc.%s:%d" ( include "etcd.stsName" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace (int $.Values.clientPort) $.Values.clusterDomain ) -}}
+    {{- $list = append $list ( printf "%s-%d.%s.%s.svc.%s:%d" ( include "etcd.stsName" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace $.Values.clusterDomain (int $.Values.clientPort) ) -}}
 {{- end }}
 {{- join " " $list -}}
 {{- end }}
@@ -147,7 +147,7 @@ Space separated list of etcd cluster endpoints.
 {{- define "etcd.endpointsYAML" }}
 {{- $outer := . -}}
 {{- range $i, $count := until (int $.Values.replicas) -}}
-    {{ printf "- %s-%d.%s.%s.svc.%s:%d\n" ( include "etcd.stsName" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace (int $.Values.clientPort) $.Values.clusterDomain }}
+    {{ printf "- %s-%d.%s.%s.svc.%s:%d\n" ( include "etcd.stsName" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace $.Values.clusterDomain (int $.Values.clientPort) }}
 {{- end }}
 {{- end }}
 

--- a/charts/kamaji-etcd/templates/_helpers.tpl
+++ b/charts/kamaji-etcd/templates/_helpers.tpl
@@ -124,7 +124,7 @@ Comma separated list of etcd cluster peers.
 {{- $outer := . -}}
 {{- $list := list -}}
 {{- range $i, $count := until (int $.Values.replicas) -}}
-    {{- $list = append $list ( printf "%s-%d=https://%s-%d.%s.%s.svc.cluster.local:%d" ( include "etcd.stsName" $outer ) $i ( include "etcd.fullname" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace (int $.Values.peerApiPort) ) -}}
+    {{- $list = append $list ( printf "%s-%d=https://%s-%d.%s.%s.svc.%s:%d" ( include "etcd.stsName" $outer ) $i ( include "etcd.fullname" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace (int $.Values.peerApiPort) $.Values.clusterDomain ) -}}
 {{- end }}
 {{- join "," $list -}}
 {{- end }}
@@ -136,7 +136,7 @@ Space separated list of etcd cluster endpoints.
 {{- $outer := . -}}
 {{- $list := list -}}
 {{- range $i, $count := until (int $.Values.replicas) -}}
-    {{- $list = append $list ( printf "%s-%d.%s.%s.svc.cluster.local:%d" ( include "etcd.stsName" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace (int $.Values.clientPort) ) -}}
+    {{- $list = append $list ( printf "%s-%d.%s.%s.svc.%s:%d" ( include "etcd.stsName" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace (int $.Values.clientPort) $.Values.clusterDomain ) -}}
 {{- end }}
 {{- join " " $list -}}
 {{- end }}
@@ -147,7 +147,7 @@ Space separated list of etcd cluster endpoints.
 {{- define "etcd.endpointsYAML" }}
 {{- $outer := . -}}
 {{- range $i, $count := until (int $.Values.replicas) -}}
-    {{ printf "- %s-%d.%s.%s.svc.cluster.local:%d\n" ( include "etcd.stsName" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace (int $.Values.clientPort) }}
+    {{ printf "- %s-%d.%s.%s.svc.%s:%d\n" ( include "etcd.stsName" $outer ) $count ( include "etcd.serviceName" $outer ) $.Release.Namespace (int $.Values.clientPort) $.Values.clusterDomain }}
 {{- end }}
 {{- end }}
 

--- a/charts/kamaji-etcd/templates/etcd_cm.yaml
+++ b/charts/kamaji-etcd/templates/etcd_cm.yaml
@@ -56,9 +56,9 @@ data:
       },
       "hosts": [
 {{- range $count := until (int $.Values.replicas) -}}
-        {{ printf "\"%s-%d.%s.%s.svc.cluster.local\"," ( include "etcd.fullname" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace }}
+        {{ printf "\"%s-%d.%s.%s.svc.%s\"," ( include "etcd.fullname" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace $.Values.clusterDomain }}
 {{- end }}
-        "etcd-server.{{ .Release.Namespace }}.svc.cluster.local",
+        "etcd-server.{{ .Release.Namespace }}.svc.{{ $.Values.clusterDomain }}",
         "etcd-server.{{ .Release.Namespace }}.svc",
         "etcd-server",
         "127.0.0.1"
@@ -76,7 +76,7 @@ data:
         {{ printf "\"%s-%d\"," ( include "etcd.stsName" $outer ) $count }}
         {{ printf "\"%s-%d.%s\"," ( include "etcd.stsName" $outer ) $count (include "etcd.serviceName" $outer) }}
         {{ printf "\"%s-%d.%s.%s.svc\"," ( include "etcd.stsName" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace }}
-        {{ printf "\"%s-%d.%s.%s.svc.cluster.local\"," ( include "etcd.stsName" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace }}
+        {{ printf "\"%s-%d.%s.%s.svc.%s\"," ( include "etcd.stsName" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace $.Values.clusterDomain }}
 {{- end }}
         "127.0.0.1"
       ]

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
@@ -40,7 +40,7 @@ spec:
             fi
           env:
             - name: ETCDCTL_ENDPOINTS
-              value: https://{{ include "etcd.fullname" . }}-0.{{ include "etcd.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.clientPort }}
+              value: https://{{ include "etcd.fullname" . }}-0.{{ include "etcd.serviceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.clientPort }}
             - name: ETCDCTL_CACERT
               value: /opt/certs/ca/ca.crt
             - name: ETCDCTL_CERT

--- a/charts/kamaji-etcd/templates/etcd_sts.yaml
+++ b/charts/kamaji-etcd/templates/etcd_sts.yaml
@@ -52,8 +52,8 @@ spec:
             - --name=$(POD_NAME)
             - --initial-cluster-state=new
             - --initial-cluster={{ include "etcd.initialCluster" . }}
-            - --initial-advertise-peer-urls=https://$(POD_NAME).{{ include "etcd.serviceName" . }}.$(POD_NAMESPACE).svc.cluster.local:{{ .Values.peerApiPort }}
-            - --advertise-client-urls=https://$(POD_NAME).{{ include "etcd.serviceName" . }}.$(POD_NAMESPACE).svc.cluster.local:{{ .Values.clientPort }}
+            - --initial-advertise-peer-urls=https://$(POD_NAME).{{ include "etcd.serviceName" . }}.$(POD_NAMESPACE).svc.{{ .Values.clusterDomain }}:{{ .Values.peerApiPort }}
+            - --advertise-client-urls=https://$(POD_NAME).{{ include "etcd.serviceName" . }}.$(POD_NAMESPACE).svc.{{ .Values.clusterDomain }}:{{ .Values.clientPort }}
             - --initial-cluster-token=kamaji
             - --listen-client-urls=https://0.0.0.0:{{ .Values.clientPort }}
             - --listen-metrics-urls=http://0.0.0.0:{{ .Values.metricsPort }}

--- a/charts/kamaji-etcd/values.yaml
+++ b/charts/kamaji-etcd/values.yaml
@@ -40,6 +40,9 @@ livenessProbe: {}
 #  periodSeconds: 10
 #  timeoutSeconds: 15
 
+# -- Domain of the Kubernetes cluster.
+clusterDomain: "cluster.local"
+
 # -- A list of extra arguments to add to the etcd default ones
 extraArgs: []
 #- --log-level=warn


### PR DESCRIPTION
Based on  https://github.com/clastix/kamaji/issues/433 and https://github.com/clastix/kamaji/pull/444

This adds a `clusterDomain` chart variable which is used when configuring the etcd services to accomodate clusters whose Kubernetes DNS domain is not `cluster.local`

Without this, etcd nodes of deployments within clusters whose domain is not `cluster.local` will not be able to reach each other through the assumed fully qualified domain name, and the cluster will never become ready.