### PR TITLE
bugfix: add affinity to all pods this chart creates

### DIFF
--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -55,7 +55,7 @@ Here the values you can override:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` | Kubernetes affinity rules to apply to etcd controller pods |
+| affinity | object | `{}` | Kubernetes affinity rules to apply to pods (jobs and etcd) |
 | alerts.annotations | object | `{}` | Assign additional Annotations |
 | alerts.enabled | bool | `false` | Enable alerts for Alertmanager |
 | alerts.labels | object | `{}` | Assign additional labels according to Prometheus' Alerts matching labels |
@@ -104,7 +104,7 @@ Here the values you can override:
 | serviceMonitor.namespace | string | `""` | Install the ServiceMonitor into a different Namespace, as the monitoring stack one (default: the release one) |
 | serviceMonitor.targetLabels | list | `[]` | Set targetLabels for the serviceMonitor |
 | snapshotCount | string | `"10000"` | Number of committed transactions to trigger a snapshot to disk. |
-| tolerations | list | `[]` | Kubernetes node taints that the etcd pods would tolerate |
+| tolerations | list | `[]` | Kubernetes node taints that the pods (jobs and etcd) would tolerate |
 | topologySpreadConstraints | list | `[]` | Kubernetes topology spread constraints to apply to etcd controller pods |
 
 ## Maintainers

--- a/charts/kamaji-etcd/templates/etcd_job_postdelete.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_postdelete.yaml
@@ -30,3 +30,6 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
@@ -61,6 +61,9 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: csr
           configMap:

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
@@ -66,6 +66,9 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: root-certs
           secret:

--- a/charts/kamaji-etcd/values.yaml
+++ b/charts/kamaji-etcd/values.yaml
@@ -99,10 +99,10 @@ resources:
 nodeSelector:
   kubernetes.io/os: linux
 
-# -- Kubernetes node taints that the etcd pods would tolerate
+# -- Kubernetes node taints that the pods (jobs and etcd) would tolerate
 tolerations: []
 
-# -- Kubernetes affinity rules to apply to etcd controller pods
+# -- Kubernetes affinity rules to apply to pods (jobs and etcd)
 affinity: {}
 
 # -- Kubernetes topology spread constraints to apply to etcd controller pods


### PR DESCRIPTION
Similarly to `tolerations`, propagate `affinity` everywhere.

Let me know if you want this handled with separate variables and if you want me to do the same with `podTopologySpreadConstraints` and `nodeSelector`.

If that is fine to merge, we would appreciate a bugfix release so that we can consume the new chart ASAP.