### PR TITLE
feat: add annotations value to datastore

### DIFF
--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -65,6 +65,7 @@ Here the values you can override:
 | autoCompactionRetention | string | `"5m"` | Auto compaction retention length. 0 means disable auto compaction. |
 | clientPort | int | `2379` | The client request port. |
 | clusterDomain | string | `"cluster.local"` | Domain of the Kubernetes cluster. |
+| datastore.annotations | object | `{}` | Assign additional Annotations to the datastore |
 | datastore.enabled | bool | `false` | Create a datastore custom resource for Kamaji |
 | datastore.name | string | `""` | Name of Kamaji datastore, set to fully qualified etcd name when null or not provided |
 | extraArgs | list | `[]` | A list of extra arguments to add to the etcd default ones |

--- a/charts/kamaji-etcd/templates/etcd_datastore.yaml
+++ b/charts/kamaji-etcd/templates/etcd_datastore.yaml
@@ -3,6 +3,10 @@ apiVersion: kamaji.clastix.io/v1alpha1
 kind: DataStore
 metadata:
   name: {{ .Values.datastore.name | default (include "etcd.fullname" .) }}
+  {{- if .Values.datastore.annotations }}
+  annotations:
+      {{- toYaml .Values.datastore.annotations | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
 spec:

--- a/charts/kamaji-etcd/values.yaml
+++ b/charts/kamaji-etcd/values.yaml
@@ -119,6 +119,9 @@ datastore:
   enabled: false
   # -- Name of Kamaji datastore, set to fully qualified etcd name when null or not provided
   name: ""
+  # -- Assign additional Annotations to the datastore
+  annotations: {}
+  #  helm.sh/resource-policy: keep
 
 serviceMonitor:
   # -- Enable ServiceMonitor for Prometheus


### PR DESCRIPTION
This allows adding annotations to the default datastore deployed through the helm chart. Specifically I'm looking to add the `helm.sh/resource-policy: keep` so helm doesn't delete this CR when we uninstall. 