### PR TITLE
Add apiVersion and Kind to pvc template on StatefulSet

### DIFF
--- a/charts/kamaji-etcd/templates/etcd_sts.yaml
+++ b/charts/kamaji-etcd/templates/etcd_sts.yaml
@@ -104,7 +104,9 @@ spec:
       topologySpreadConstraints: {{- toYaml . | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- with .Values.persistentVolumeClaim.customAnnotations }}
         annotations:


### PR DESCRIPTION
Small change to specify `apiVersion` and `kind` on the StatefulSet `volumeClaimTemplate` so ArgoCD (and potentially other tools) doesn't show OutOfSync

close #85 