### PR TITLE
feat: switch between client and headless service

### DIFF
--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -67,6 +67,7 @@ Here the values you can override:
 | clusterDomain | string | `"cluster.local"` | Domain of the Kubernetes cluster. |
 | datastore.annotations | object | `{}` | Assign additional Annotations to the datastore |
 | datastore.enabled | bool | `false` | Create a datastore custom resource for Kamaji |
+| datastore.headless | bool | `true` | Expose the headless service endpoints in the datastore. Set to false to expose with regular service. |
 | datastore.name | string | `""` | Name of Kamaji datastore, set to fully qualified etcd name when null or not provided |
 | extraArgs | list | `[]` | A list of extra arguments to add to the etcd default ones |
 | fullnameOverride | string | `""` |  |

--- a/charts/kamaji-etcd/templates/_helpers.tpl
+++ b/charts/kamaji-etcd/templates/_helpers.tpl
@@ -43,6 +43,13 @@ Create the name of the Service to use
 {{- end }}
 
 {{/*
+Create the name of the client Service to use
+*/}}
+{{- define "client.serviceName" -}}
+{{- printf "%s-client" (include "etcd.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "etcd.labels" -}}
@@ -157,8 +164,8 @@ Space separated list of etcd cluster endpoints.
 {{- end }}
 
 {{/*
-Create the minio-client fully-qualified Docker image to use
+Client cluster endpoints.
 */}}
-{{- define "minio-client.fullyQualifiedDockerImage" -}}
-{{- printf "%s:%s" .Values.backup.s3.image.repository .Values.backup.s3.image.tag -}}
+{{- define "client.endpointsYAML" }}
+{{ printf "- %s.%s.svc.%s:%d\n" ( include "client.serviceName" .) $.Release.Namespace $.Values.clusterDomain (int $.Values.clientPort) }}
 {{- end }}

--- a/charts/kamaji-etcd/templates/etcd_client_service.yaml
+++ b/charts/kamaji-etcd/templates/etcd_client_service.yaml
@@ -3,15 +3,13 @@ kind: Service
 metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
-  name: {{ include "etcd.serviceName" . }}
+  name: {{ include "client.serviceName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  clusterIP: None
+  type: ClusterIP
   ports:
     - port: {{ .Values.clientPort }}
       name: client
-    - port: {{ .Values.peerApiPort }}
-      name: peer
     - port: {{ .Values.metricsPort }}
       name: metrics
   selector:

--- a/charts/kamaji-etcd/templates/etcd_client_service.yaml
+++ b/charts/kamaji-etcd/templates/etcd_client_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
+    prometheus.io/metrics: "true"
   name: {{ include "client.serviceName" . }}
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/kamaji-etcd/templates/etcd_cm.yaml
+++ b/charts/kamaji-etcd/templates/etcd_cm.yaml
@@ -58,6 +58,7 @@ data:
 {{- range $count := until (int $.Values.replicas) -}}
         {{ printf "\"%s-%d.%s.%s.svc.%s\"," ( include "etcd.fullname" $outer ) $count (include "etcd.serviceName" $outer) $.Release.Namespace $.Values.clusterDomain }}
 {{- end }}
+        {{ printf "\"%s.%s.svc.%s\"," (include "client.serviceName" .) $.Release.Namespace $.Values.clusterDomain }}
         "etcd-server.{{ .Release.Namespace }}.svc.{{ $.Values.clusterDomain }}",
         "etcd-server.{{ .Release.Namespace }}.svc",
         "etcd-server",

--- a/charts/kamaji-etcd/templates/etcd_datastore.yaml
+++ b/charts/kamaji-etcd/templates/etcd_datastore.yaml
@@ -12,7 +12,11 @@ metadata:
 spec:
   driver: etcd
   endpoints:
-  {{- include "etcd.endpointsYAML" . | nindent 4 }}
+  {{- if or (not (hasKey .Values.datastore "headless")) .Values.datastore.headless }}
+    {{- include "etcd.endpointsYAML" . | nindent 4 }}
+  {{- else }}
+    {{- include "client.endpointsYAML" . | nindent 4 }}
+  {{- end }}
   tlsConfig:
     certificateAuthority:
       certificate:

--- a/charts/kamaji-etcd/templates/etcd_headless_service.yaml
+++ b/charts/kamaji-etcd/templates/etcd_headless_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "etcd.labels" . | nindent 4 }}
+  name: {{ include "etcd.serviceName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.clientPort }}
+      name: client
+    - port: {{ .Values.peerApiPort }}
+      name: peer
+  selector:
+    {{- include "etcd.selectorLabels" . | nindent 4 }}

--- a/charts/kamaji-etcd/templates/etcd_service_monitor.yaml
+++ b/charts/kamaji-etcd/templates/etcd_service_monitor.yaml
@@ -38,7 +38,8 @@ spec:
     {{- if .Values.serviceMonitor.matchLabels }}
       {{- toYaml .Values.serviceMonitor.matchLabels | nindent 6 }}
     {{- else }}
-      {{- include "etcd.labels" . | nindent 6 }}
+      prometheus.io/metrics: "true"
+      {{- include "etcd.selectorLabels" . | nindent 6 }}
     {{- end }}
   namespaceSelector:
     matchNames:

--- a/charts/kamaji-etcd/values.yaml
+++ b/charts/kamaji-etcd/values.yaml
@@ -128,6 +128,8 @@ datastore:
   enabled: false
   # -- Name of Kamaji datastore, set to fully qualified etcd name when null or not provided
   name: ""
+  # -- Expose the headless service endpoints in the datastore. Set to false to expose with regular service.
+  headless: true # https://github.com/clastix/kamaji/issues/856
   # -- Assign additional Annotations to the datastore
   annotations: {}
   #  helm.sh/resource-policy: keep


### PR DESCRIPTION
This PR addresses concerns described [here](https://github.com/clastix/kamaji/issues/856). Now you can set between headless service endpoints (default behaviour) and regular ClusterIP service:

```yaml
datastore:
  # -- Create a datastore custom resource for Kamaji
  enabled: false
  # -- Name of Kamaji datastore, set to fully qualified etcd name when null or not provided
  name: ""
  # -- Expose the headless service endpoints in the datastore. Set to false to expose with regular service.
  headless: true # https://github.com/clastix/kamaji/issues/856
  # -- Assign additional Annotations to the datastore
  annotations: {}
  #  helm.sh/resource-policy: keep
```

Keeping the old behaviour as default, it should be safe for upgrades, i.e. considering missing value as true:

```yaml
apiVersion: kamaji.clastix.io/v1alpha1
kind: DataStore
metadata:
  name: {{ .Values.datastore.name | default (include "etcd.fullname" .) }}
  {{- if .Values.datastore.annotations }}
  annotations:
      {{- toYaml .Values.datastore.annotations | nindent 4 }}
  {{- end }}
  labels:
    {{- include "etcd.labels" . | nindent 4 }}
spec:
  driver: etcd
  endpoints:
  {{- if or (not (hasKey .Values.datastore "headless")) .Values.datastore.headless }}
    {{- include "etcd.endpointsYAML" . | nindent 4 }}
  {{- else }}
    {{- include "client.endpointsYAML" . | nindent 4 }}
  {{- end }}
```

