### PR TITLE
feat: configurable job image repositories

### DIFF
--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -76,7 +76,12 @@ Here the values you can override:
 | image.tag | string | `""` | Install image with specific tag, overwrite the tag in the chart |
 | imagePullSecrets | list | `[]` |  |
 | jobs.affinity | object | `{}` | Kubernetes affinity rules to apply to ancillary jobs |
-| jobs.image | object | `{"pullPolicy":"IfNotPresent","repository":"quay.io/coreos/etcd","tag":"v3.5.6"}` | etcd image to use for ancillary jobs |
+| jobs.cfssl | object | `{"image":"cfssl/cfssl","tag":""}` | addional images to use for ancillary jobs |
+| jobs.etcd.image | string | `"quay.io/coreos/etcd"` |  |
+| jobs.etcd.pullPolicy | string | `"IfNotPresent"` |  |
+| jobs.etcd.tag | string | `"v3.5.6"` |  |
+| jobs.kubectl.image | string | `"clastix/kubectl"` |  |
+| jobs.kubectl.tag | string | `""` |  |
 | jobs.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Kubernetes node selector rules for ancillary jobs |
 | jobs.tolerations | list | `[]` | Kubernetes node taints that the ancillary jobs would tolerate |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/livez","port":2381,"scheme":"HTTP"},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":15}` | The livenessProbe for the etcd container |

--- a/charts/kamaji-etcd/templates/etcd_job_postdelete.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_postdelete.yaml
@@ -19,7 +19,7 @@ spec:
       nodeSelector: {{- toYaml .Values.jobs.nodeSelector | nindent 8 }}
       containers:
         - name: kubectl
-          image: {{ printf "clastix/kubectl:%s" (include "etcd.jobsTagKubeVersion" .) }}
+          image: "{{ printf "%s:%s" .Values.jobs.kubectl.image (default (include "etcd.jobsTagKubeVersion" . | trim) .Values.jobs.kubectl.tag) }}"
           command:
             - kubectl
             - --namespace={{ .Release.Namespace }}

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: cfssl
-          image: cfssl/cfssl:latest
+          image:  "{{ printf "%s:%s" .Values.jobs.cfssl.image (default "latest" .Values.jobs.cfssl.tag) }}"
           command:
             - bash
             - -c
@@ -35,7 +35,7 @@ spec:
               name: csr
       containers:
         - name: kubectl
-          image: {{ printf "clastix/kubectl:%s" (include "etcd.jobsTagKubeVersion" .) }}
+          image: "{{ printf "%s:%s" .Values.jobs.kubectl.image (default (include "etcd.jobsTagKubeVersion" . | trim) .Values.jobs.kubectl.tag) }}"
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
@@ -18,7 +18,7 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: cfssl
-          image:  "{{ printf "%s:%s" .Values.jobs.cfssl.image (default "latest" .Values.jobs.cfssl.tag) }}"
+          image: "{{ printf "%s:%s" .Values.jobs.cfssl.image (default "latest" .Values.jobs.cfssl.tag) }}"
           command:
             - bash
             - -c

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
@@ -23,7 +23,7 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: kubectl
-          image: {{ printf "clastix/kubectl:%s" (include "etcd.jobsTagKubeVersion" .) }}
+          image: "{{ printf "%s:%s" .Values.jobs.kubectl.image (default (include "etcd.jobsTagKubeVersion" . | trim) .Values.jobs.kubectl.tag) }}"
           command:
           - sh
           - -c
@@ -51,8 +51,8 @@ spec:
               value: /opt/certs/root-certs/tls.crt
             - name: ETCDCTL_KEY
               value: /opt/certs/root-certs/tls.key
-          image: {{ .Values.jobs.image.repository }}:{{ .Values.jobs.image.tag }}
-          imagePullPolicy: {{ .Values.jobs.image.pullPolicy }}
+          image: "{{ printf "%s:%s" .Values.jobs.etcd.image (default "latest" .Values.jobs.etcd.tag) }}"
+          imagePullPolicy: {{ .Values.jobs.etcd.pullPolicy }}
           name: etcd-client
           volumeMounts:
             - name: root-certs

--- a/charts/kamaji-etcd/values.yaml
+++ b/charts/kamaji-etcd/values.yaml
@@ -207,9 +207,14 @@ jobs:
   tolerations: []
   # -- Kubernetes affinity rules to apply to ancillary jobs
   affinity: {}
-  # -- etcd image to use for ancillary jobs
-  image:
-    repository: quay.io/coreos/etcd
+  # -- addional images to use for ancillary jobs
+  cfssl:
+    image: cfssl/cfssl
+    tag: ""
+  kubectl:
+    image: clastix/kubectl
+    tag: ""
+  etcd:
+    image: quay.io/coreos/etcd
     tag: v3.5.6 # latest container image with shell available!
     pullPolicy: IfNotPresent
-  


### PR DESCRIPTION
this PR enables config overwrites for all container images used within the various jobs. This allows to deploy kamaji-etcd in contained environments with no access to public or mirror repositories.