### PR TITLE
feat: allow to skip ca creation and set custom ca name

### DIFF
--- a/charts/kamaji-etcd/templates/_helpers.tpl
+++ b/charts/kamaji-etcd/templates/_helpers.tpl
@@ -98,7 +98,7 @@ Name of the etcd CA secret.
 Name of the etcd CA secret.
 */}}
 {{- define "etcd.certManager.ca" }}
-{{- printf "%s-%s" (include "etcd.fullname" .) "ca" | trunc 63 | trimSuffix "-" }}
+{{- default (printf "%s-%s" (include "etcd.fullname" .) "ca" | trunc 63 | trimSuffix "-") .Values.certManager.ca.name }}
 {{- end }}
 
 {{/*

--- a/charts/kamaji-etcd/templates/etcd_cert_manager.yaml
+++ b/charts/kamaji-etcd/templates/etcd_cert_manager.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.certManager.enabled }}
+{{- if .Values.certManager.ca.create }}
 ---
 apiVersion: v1
 kind: Secret
@@ -7,6 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data: {}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -31,6 +33,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data: {}
+{{- if .Values.certManager.ca.create }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -62,6 +65,7 @@ metadata:
 spec:
   ca:
     secretName: {{ include "etcd.certManager.ca" . }}
+{{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/charts/kamaji-etcd/values.yaml
+++ b/charts/kamaji-etcd/values.yaml
@@ -229,4 +229,6 @@ certManager:
   #  group: cert-manager.io
   # -- CertManager etcd CA validity
   ca:
-   validity: 87600h # 10 years
+    name: ""
+    create: true
+    validity: 87600h # 10 years


### PR DESCRIPTION
Related to [this PR](https://github.com/clastix/kamaji/pull/961).

Allows to skip CA creation and specify a custom CA name in order to use a user supplied CA when using Cert-manager.
This is useful if you want a common CA between `Datastores` to use in conjunction with `--etcd-servers-overrides`.