### PR TITLE
feat(deps): bump etcd to 3.5.26

### DIFF
--- a/charts/kamaji-etcd/Chart.yaml
+++ b/charts/kamaji-etcd/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.0
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.5.17"
+appVersion: "3.5.26"
 
 home: https://github.com/clastix/kamaji-etcd
 sources: ["https://github.com/clastix/kamaji-etcd"]

--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -1,6 +1,6 @@
 # kamaji-etcd
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.17](https://img.shields.io/badge/AppVersion-3.5.17-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.26](https://img.shields.io/badge/AppVersion-3.5.26-informational?style=flat-square)
 
 Helm chart for deploying a multi-tenant `etcd` cluster.
 


### PR DESCRIPTION
Version update for helm chart in order to bump kamaji-etcd AppVersion to 3.5.26 