### PR TITLE
feat(deps): bump etcd to 3.6.12 

### DIFF
--- a/charts/kamaji-etcd/Chart.yaml
+++ b/charts/kamaji-etcd/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.0
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.5.26"
+appVersion: "3.6.12"
 
 home: https://github.com/clastix/kamaji-etcd
 sources: ["https://github.com/clastix/kamaji-etcd"]

--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -1,6 +1,6 @@
 # kamaji-etcd
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.5.26](https://img.shields.io/badge/AppVersion-3.5.26-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.12](https://img.shields.io/badge/AppVersion-3.6.12-informational?style=flat-square)
 
 Helm chart for deploying a multi-tenant `etcd` cluster.
 


### PR DESCRIPTION
This pull request updates the Helm chart for `kamaji-etcd` to a new version, reflecting an upgrade of the underlying etcd application and chart metadata.

Version upgrades:

* Bumped the chart version in `Chart.yaml` from `0.16.0` to `0.17.0` and the application version from `3.5.26` to `3.6.12` to match the new etcd release.
* Updated the version badges in `README.md` to reflect the new chart and app versions.

> [!NOTE]
> To avoid breaking changes, ensure you are running version `0.15.0` (`3.5.26`) before updating. ([Source](https://etcd.io/docs/v3.6/upgrades/upgrade_3_6/#:~:text=Before%20upgrading%20to%203%2E6%2C%20make%20sure%20that%20all%20of%20your%203%2E5%20members%20are%20updated%20to%203%2E5%2E26%20or%20later%2E%20Patch%20releases%203%2E5%2E24%20through%203%2E5%2E26%20fix%20several%20potential%20upgrade%20blockers))
