### PR TITLE
fix: make setup jobs' securityContext configurable for restricted PodSecurity

### DIFF
--- a/charts/kamaji-etcd/README.md
+++ b/charts/kamaji-etcd/README.md
@@ -96,6 +96,8 @@ Here the values you can override:
 | jobs.kubectl.image | string | `"clastix/kubectl"` |  |
 | jobs.kubectl.tag | string | `""` |  |
 | jobs.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Kubernetes node selector rules for ancillary jobs |
+| jobs.podSecurityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsUser":1000}` | The securityContext to apply to ancillary job pods |
+| jobs.securityContext | object | `{"allowPrivilegeEscalation":false}` | The securityContext to apply to ancillary job containers (init and main) |
 | jobs.tolerations | list | `[]` | Kubernetes node taints that the ancillary jobs would tolerate |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/livez","port":2381,"scheme":"HTTP"},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":15}` | The livenessProbe for the etcd container |
 | metricsPort | int | `2381` | The port where etcd exposes metrics. |

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml
@@ -20,6 +20,8 @@ spec:
       initContainers:
         - name: cfssl
           image: "{{ printf "%s:%s" .Values.jobs.cfssl.image (default "latest" .Values.jobs.cfssl.tag) }}"
+          securityContext:
+            {{- toYaml .Values.jobs.securityContext | nindent 12 }}
           command:
             - bash
             - -c
@@ -37,6 +39,8 @@ spec:
       containers:
         - name: kubectl
           image: "{{ printf "%s:%s" .Values.jobs.kubectl.image (default (include "etcd.jobsTagKubeVersion" . | trim) .Values.jobs.kubectl.tag) }}"
+          securityContext:
+            {{- toYaml .Values.jobs.securityContext | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -56,9 +60,7 @@ spec:
             - mountPath: /certs
               name: certs
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+      {{- toYaml .Values.jobs.podSecurityContext | nindent 8 }}
       nodeSelector: {{- toYaml .Values.jobs.nodeSelector | nindent 8 }}
       {{- with .Values.jobs.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}

--- a/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
+++ b/charts/kamaji-etcd/templates/etcd_job_preinstall_2.yaml
@@ -24,6 +24,8 @@ spec:
       initContainers:
         - name: kubectl
           image: "{{ printf "%s:%s" .Values.jobs.kubectl.image (default (include "etcd.jobsTagKubeVersion" . | trim) .Values.jobs.kubectl.tag) }}"
+          securityContext:
+            {{- toYaml .Values.jobs.securityContext | nindent 12 }}
           command:
           - sh
           - -c
@@ -54,15 +56,15 @@ spec:
           image: "{{ printf "%s:%s" .Values.jobs.etcd.image (default "latest" .Values.jobs.etcd.tag) }}"
           imagePullPolicy: {{ .Values.jobs.etcd.pullPolicy }}
           name: etcd-client
+          securityContext:
+            {{- toYaml .Values.jobs.securityContext | nindent 12 }}
           volumeMounts:
             - name: root-certs
               mountPath: /opt/certs/root-certs
             - name: ca
               mountPath: /opt/certs/ca
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+      {{- toYaml .Values.jobs.podSecurityContext | nindent 8 }}
       nodeSelector: {{- toYaml .Values.jobs.nodeSelector | nindent 8 }}
       {{- with .Values.jobs.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}

--- a/charts/kamaji-etcd/values.yaml
+++ b/charts/kamaji-etcd/values.yaml
@@ -223,6 +223,14 @@ jobs:
     image: quay.io/coreos/etcd
     tag: v3.5.6 # latest container image with shell available!
     pullPolicy: IfNotPresent
+  # -- The securityContext to apply to ancillary job containers (init and main)
+  securityContext:
+    allowPrivilegeEscalation: false
+  # -- The securityContext to apply to ancillary job pods
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
 
 selfSignedCertificates:
   # -- Enables the generation of self-signed certificates for etcd using the cfssl, and kubectl jobs.


### PR DESCRIPTION
## What
Expose `jobs.securityContext` and `jobs.podSecurityContext` and apply them at
pod and container level (init + main) in both etcd setup Jobs
(`*-etcd-setup-1`, `*-etcd-setup-2`).

## Why
The setup Jobs set `securityContext` only at pod level. Under PodSecurity
`restricted`, admission requires `allowPrivilegeEscalation: false`,
`capabilities.drop: ["ALL"]`, `runAsNonRoot: true` and
`seccompProfile.type: RuntimeDefault` **per container** — the first two have no
pod-level equivalent. With no values hook, the Jobs could not be hardened, so
`*-etcd-setup-2` failed admission, etcd auth was never enabled, and Flux-driven
installs timed out. This completes #128 for the Jobs.

## Design
Minimal, behavior-preserving defaults that mirror #128's opt-in
`securityContext`/`podSecurityContext` convention on the StatefulSet — not
restricted-compliant-by-default — so existing deployments are unchanged and
operators opt into hardening via values, exactly as for the StatefulSet.

## Testing
`helm lint` and `helm template` (default values and a `restricted` overlay)
confirm the securityContext is applied to all four containers and both pods;
the default pod render is semantically unchanged.

## Note
Defaults intentionally omit `readOnlyRootFilesystem`. An operator who enables it
on `jobs.securityContext` must keep the `cfssl` container's cert write paths
writable (`/certs` is already an `emptyDir`).
